### PR TITLE
Obtain TLS certs with LE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,69 @@
 # Juju reactive charm layer for Mattermost
 
-## Build
+# Build
 
 In this directory:
 
-    $ charm build
+    charm build
 
-## Deploy
+# Deploy
 
-To deploy the locally-built charm:
+## TLS Options
 
-    $ juju deploy cs:~cmars/mattermost
-    $ juju deploy postgresql
-    $ juju deploy cs:~containers/easyrsa
-    $ juju add-relation postgresql:db mattermost:db
-    $ juju add-relation easyrsa mattermost
+Deployment requires agreement to ISRG terms of service, because Let's Encrypt
+is the primary and recommended method for setting up TLS.
+
+### Secured with Let's Encrypt in public clouds
+
+Deploy to a public cloud and expose it.
+
+    juju deploy cs:~cmars/mattermost
+    juju deploy postgresql
+    juju add-relation mattermost postgresql:db
+    juju expose mattermost
+
+Acquire a DNS name for the instance. Then set `fqdn` to the DNS name.
+
+    juju config mattermost fqdn=chat.cmars.tech
+
+Let's Encrypt will do the rest. When the workload state becomes active, your
+Mattermost instance is ready to set up.
+
+If registration fails, check:
+
+- That you've exposed mattermost. Let's Encrypt needs to connect to ports 80
+  and 443 as part of the registration process.
+- That the DNS name has had time to propagate.
+- That the DNS name is allowed by Let's Encrypt. Some names, like the dynamic
+  ones given to EC2 instances, may not be allowed.
+
+### Secured with your own TLS PKI regime
+
+This charm also supports `interface:tls-client`, so you can use your own CA.
+
+    juju deploy cs:~cmars/mattermost
+    juju deploy postgresql
+    juju deploy cs:~containers/easyrsa
+    juju add-relation postgresql:db mattermost:db
+    juju add-relation easyrsa mattermost
+
+### Reverse-proxied by a front-end
+
+    juju deploy cs:~cmars/mattermost
+    juju deploy postgresql
+    juju deploy haproxy
+    juju add-relation postgresql:db mattermost:db
+    juju add-relation haproxy mattermost
+
+## Alternative binary distributions
 
 To deploy with your own Mattermost binary distribution:
 
-    $ juju deploy cs:~cmars/mattermost --resource bdist=/path/to/mattermost.tar.gz
+    juju deploy cs:~cmars/mattermost --resource bdist=/path/to/mattermost.tar.gz
 
 Note that Mattermost releases prior to 2.1.0 have not been tested.
 
-## License
+# License
 
 Copyright 2016 Casey Marshall.
 
@@ -30,7 +71,7 @@ The [copyright](copyright) file contains the software license for this charm.
 
 Mattermost is a trademark of Mattermost, Inc.
 
-### Disclaimer
+## Disclaimer
 
 This charm automates installation, configuration and management of a Mattermost
 server based on publicly documented best practices. This charm is not a part of
@@ -41,8 +82,11 @@ See the [Mattermost](http://www.mattermost.org/) website for more information
 about the licenses and trademarks applicable to the software installed by this
 charm.
 
-## Contact
+# Contact
 
 Email: charmed at cmars.tech
+
 IRC: cmars on FreeNode
+
 Mattermost: Coming soon...
+

--- a/README.md
+++ b/README.md
@@ -33,21 +33,13 @@ If registration fails, check:
 
 - That you've exposed mattermost. Let's Encrypt needs to connect to ports 80
   and 443 as part of the registration process.
-- That the DNS name has had time to propagate.
+- That the DNS name has had time to propagate and cached entries have expired.
 - That the DNS name is allowed by Let's Encrypt. Some names, like the dynamic
   ones given to EC2 instances, may not be allowed.
 
-### Secured with your own TLS PKI regime
-
-This charm also supports `interface:tls-client`, so you can use your own CA.
-
-    juju deploy cs:~cmars/mattermost
-    juju deploy postgresql
-    juju deploy cs:~containers/easyrsa
-    juju add-relation postgresql:db mattermost:db
-    juju add-relation easyrsa mattermost
-
 ### Reverse-proxied by a front-end
+
+With `fqdn` unset, relate mattermost to a reverse proxy.
 
     juju deploy cs:~cmars/mattermost
     juju deploy postgresql

--- a/config.yaml
+++ b/config.yaml
@@ -10,4 +10,4 @@ options:
     type: int
     description: Nginx listen port
     default: 80
-    
+ 

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,14 +1,6 @@
 includes:
  - 'layer:basic'
  - 'layer:lets-encrypt'
- - 'layer:tls-client'
  - 'interface:pgsql'
  - 'interface:http'
 repo: https://github.com/cmars/juju-charm-mattermost.git
-options:
-  tls-client:
-    ca_certificate_path: "/etc/ssl/certs/ca.crt"
-    server_certificate_path: "/etc/ssl/certs/server.crt"
-    server_key_path: "/etc/ssl/certs/server.key"
-    client_certificate_path: "/etc/ssl/certs/client.crt"
-    client_key_path: "/etc/ssl/certs/client.key"

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,6 +1,6 @@
 includes:
  - 'layer:basic'
- - 'layer:nginx'
+ - 'layer:lets-encrypt'
  - 'layer:tls-client'
  - 'interface:pgsql'
  - 'interface:http'


### PR DESCRIPTION
Instead of using layer:tls-client, the charm now supports two modes:

1. Standalone mode, using Let's Encrypt to obtain TLS certificates automatically.
2. Backend mode, which relies on a frontend for TLS termination.

The README explains these in greater detail.